### PR TITLE
Mobile transfer

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -45,7 +45,6 @@ import {
   type PagedQuery,
 } from 'loot-core/client/query-helpers';
 import { type AppDispatch } from 'loot-core/client/store';
-import { validForTransfer } from 'loot-core/client/transfer';
 import { send, listen } from 'loot-core/platform/client/fetch';
 import * as undo from 'loot-core/platform/client/undo';
 import { type UndoState } from 'loot-core/server/undo';

--- a/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.tsx
@@ -347,6 +347,7 @@ function TransactionListWithPreviews({
       onSearch={onSearch}
       onOpenTransaction={onOpenTransaction}
       onRefresh={onRefresh}
+      showMakeTransfer={accountId === 'uncategorized'}
     />
   );
 }

--- a/packages/desktop-client/src/components/mobile/budget/CategoryTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/CategoryTransactions.tsx
@@ -128,6 +128,7 @@ export function CategoryTransactions({
           onLoadMore={loadMoreTransactions}
           onOpenTransaction={onOpenTransaction}
           onRefresh={undefined}
+          showMakeTransfer={true}
         />
       </SchedulesProvider>
     </Page>

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionList.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionList.tsx
@@ -19,8 +19,10 @@ import { Popover } from '@actual-app/components/popover';
 import { styles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
 import { View } from '@actual-app/components/view';
+import { t } from 'i18next';
 
 import { setNotificationInset } from 'loot-core/client/actions';
+import { validForTransfer } from 'loot-core/client/transfer';
 import * as monthUtils from 'loot-core/shared/months';
 import { isPreviewId } from 'loot-core/shared/transactions';
 import { groupById, integerToCurrency } from 'loot-core/shared/util';
@@ -45,7 +47,6 @@ import { useScrollListener } from '../../ScrollProvider';
 import { FloatingActionBar } from '../FloatingActionBar';
 
 import { TransactionListItem } from './TransactionListItem';
-import { validForTransfer } from 'loot-core/client/transfer';
 
 const NOTIFICATION_BOTTOM_INSET = 75;
 
@@ -240,6 +241,7 @@ function SelectedTransactionsFloatingActionBar({
     <T extends string>(item: MenuItemObject<T>) => ({
       ...styles.mobileMenuItem,
       color: theme.mobileHeaderText,
+      ...(item.disabled === true && { color: theme.buttonBareDisabledText }),
       ...(item.name === 'delete' && { color: theme.errorTextMenu }),
     }),
     [],
@@ -324,33 +326,33 @@ function SelectedTransactionsFloatingActionBar({
   const moreOptionsMenuItems: MenuItem<string>[] = [
     {
       name: 'duplicate',
-      text: 'Duplicate',
+      text: t('Duplicate'),
     },
   ];
 
   if (allTransactionsAreLinked) {
     moreOptionsMenuItems.push({
       name: 'unlink-schedule',
-      text: 'Unlink schedule',
+      text: t('Unlink schedule'),
     });
   } else {
     moreOptionsMenuItems.push({
       name: 'link-schedule',
-      text: 'Link schedule',
+      text: t('Link schedule'),
     });
   }
 
   if (showMakeTransfer) {
     moreOptionsMenuItems.push({
       name: 'transfer',
-      text: 'Make transfer',
+      text: t('Make transfer'),
       disabled: !canBeTransfer,
     });
   }
 
   moreOptionsMenuItems.push({
     name: 'delete',
-    text: 'Delete',
+    text: t('Delete'),
   });
 
   return (
@@ -399,7 +401,7 @@ function SelectedTransactionsFloatingActionBar({
           <Button
             variant="bare"
             ref={editMenuTriggerRef}
-            aria-label="Edit fields"
+            aria-label={t('Edit fields')}
             onPress={() => {
               setIsEditMenuOpen(true);
             }}
@@ -482,19 +484,19 @@ function SelectedTransactionsFloatingActionBar({
                 // },
                 {
                   name: 'account',
-                  text: 'Account',
+                  text: t('Account'),
                 },
                 {
                   name: 'payee',
-                  text: 'Payee',
+                  text: t('Payee'),
                 },
                 {
                   name: 'notes',
-                  text: 'Notes',
+                  text: t('Notes'),
                 },
                 {
                   name: 'category',
-                  text: 'Category',
+                  text: t('Category'),
                 },
                 // Add support later on until we have more user friendly amount input modal.
                 // {
@@ -503,7 +505,7 @@ function SelectedTransactionsFloatingActionBar({
                 // },
                 {
                   name: 'cleared',
-                  text: 'Cleared',
+                  text: t('Cleared'),
                 },
               ]}
             />
@@ -512,7 +514,7 @@ function SelectedTransactionsFloatingActionBar({
           <Button
             variant="bare"
             ref={moreOptionsMenuTriggerRef}
-            aria-label="More options"
+            aria-label={t('More options')}
             onPress={() => {
               setIsMoreOptionsMenuOpen(true);
             }}
@@ -540,7 +542,10 @@ function SelectedTransactionsFloatingActionBar({
                     ids: selectedTransactionsArray,
                     onSuccess: ids => {
                       showUndoNotification({
-                        message: `Successfully duplicated ${ids.length} transaction${ids.length > 1 ? 's' : ''}.`,
+                        message: t(
+                          'Successfully duplicated {{count}} transactions.',
+                          { count: ids.length },
+                        ),
                       });
                     },
                   });
@@ -551,7 +556,10 @@ function SelectedTransactionsFloatingActionBar({
                       // TODO: When schedule becomes available in mobile, update undo notification message
                       // with `messageActions` to open the schedule when the schedule name is clicked.
                       showUndoNotification({
-                        message: `Successfully linked ${ids.length} transaction${ids.length > 1 ? 's' : ''} to ${schedule.name}.`,
+                        message: t(
+                          'Successfully linked {{count}} transactions to {{schedule}}.',
+                          { count: ids.length, schedule: schedule.name },
+                        ),
                       });
                     },
                   });
@@ -560,7 +568,10 @@ function SelectedTransactionsFloatingActionBar({
                     ids: selectedTransactionsArray,
                     onSuccess: ids => {
                       showUndoNotification({
-                        message: `Successfully unlinked ${ids.length} transaction${ids.length > 1 ? 's' : ''} from their respective schedules.`,
+                        message: t(
+                          'Successfully unlinked {{count}} transactions from their respective schedules.',
+                          { count: ids.length },
+                        ),
                       });
                     },
                   });
@@ -570,14 +581,22 @@ function SelectedTransactionsFloatingActionBar({
                     onSuccess: ids => {
                       showUndoNotification({
                         type: 'warning',
-                        message: `Successfully deleted ${ids.length} transaction${ids.length > 1 ? 's' : ''}.`,
+                        message: t(
+                          'Successfully deleted {{count}} transactions.',
+                          { count: ids.length },
+                        ),
                       });
                     },
                   });
                 } else if (type === 'transfer') {
                   onSetTransfer?.(selectedTransactionsArray, payees, ids =>
                     showUndoNotification({
-                      message: `Successfully marked ${ids.length} as transfer`,
+                      message: t(
+                        'Successfully marked {{count}} transactions as transfer.',
+                        {
+                          count: ids.length,
+                        },
+                      ),
                     }),
                   );
                 }

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionList.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionList.tsx
@@ -268,6 +268,7 @@ function SelectedTransactionsFloatingActionBar({
     onBatchDelete,
     onBatchLinkSchedule,
     onBatchUnlinkSchedule,
+    onSetTransfer,
   } = useTransactionBatchActions();
 
   const navigate = useNavigate();
@@ -509,6 +510,12 @@ function SelectedTransactionsFloatingActionBar({
                       });
                     },
                   });
+                } else if (type === 'transfer') {
+                  onSetTransfer?.([...selectedTransactions], payees, ids =>
+                    showUndoNotification({
+                      message: `Successfully marked ${ids.length} as transfer`,
+                    }),
+                  );
                 }
                 setIsMoreOptionsMenuOpen(false);
               }}
@@ -530,6 +537,10 @@ function SelectedTransactionsFloatingActionBar({
                         text: 'Link schedule',
                       },
                     ]),
+                {
+                  name: 'transfer',
+                  text: 'Make transfer',
+                },
                 {
                   name: 'delete',
                   text: 'Delete',

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionListWithBalances.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionListWithBalances.tsx
@@ -91,6 +91,7 @@ type TransactionListWithBalancesProps = {
   onLoadMore: () => void;
   onOpenTransaction: (transaction: TransactionEntity) => void;
   onRefresh?: () => void;
+  showMakeTransfer: boolean;
 };
 
 export function TransactionListWithBalances({
@@ -105,6 +106,7 @@ export function TransactionListWithBalances({
   onLoadMore,
   onOpenTransaction,
   onRefresh,
+  showMakeTransfer,
 }: TransactionListWithBalancesProps) {
   const selectedInst = useSelected('transactions', [...transactions], []);
 
@@ -148,6 +150,7 @@ export function TransactionListWithBalances({
             isLoadingMore={isLoadingMore}
             onLoadMore={onLoadMore}
             onOpenTransaction={onOpenTransaction}
+            showMakeTransfer={showMakeTransfer}
           />
         </PullToRefresh>
       </>

--- a/packages/desktop-client/src/components/reports/reports/Calendar.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Calendar.tsx
@@ -695,6 +695,7 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
                       transactions={allTransactions}
                       onOpenTransaction={onOpenTransaction}
                       isLoadingMore={false}
+                      showMakeTransfer={false}
                     />
                   </View>
                 </animated.div>

--- a/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
+++ b/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
@@ -1,5 +1,6 @@
 import { pushModal } from 'loot-core/client/actions';
 import { runQuery } from 'loot-core/client/query-helpers';
+import { validForTransfer } from 'loot-core/client/transfer';
 import { send } from 'loot-core/platform/client/fetch';
 import * as monthUtils from 'loot-core/shared/months';
 import { q } from 'loot-core/shared/query';
@@ -12,14 +13,13 @@ import {
 } from 'loot-core/shared/transactions';
 import { applyChanges, type Diff } from 'loot-core/shared/util';
 import {
-  PayeeEntity,
+  type PayeeEntity,
   type AccountEntity,
   type ScheduleEntity,
   type TransactionEntity,
 } from 'loot-core/types/models';
 
 import { useDispatch } from '../redux';
-import { validForTransfer } from 'loot-core/client/transfer';
 
 type BatchEditProps = {
   name: keyof TransactionEntity;

--- a/upcoming-release-notes/4511.md
+++ b/upcoming-release-notes/4511.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [rugulous]
+---
+
+Allow marking transactions as Transfers on mobile/small screen devices


### PR DESCRIPTION
Adds the functionality to mark transactions as Transfers on mobile devices. This involves moving the existing functionality into an existing shared object and updating the menu styling to make it clear when the option is disabled. I also spotted some messages that were not marked for translation so wrapped them in the `t()` function